### PR TITLE
handle spaces on path 

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -3,7 +3,7 @@ function! SafeMakeDir()
         if !isdirectory(outdir)
             call mkdir(outdir)
         endif
-    return outdir
+    return fnameescape(outdir)
 endfunction
 
 function! SaveFileTMPLinux(imgdir, tmpname) abort


### PR DESCRIPTION
I had a issue with xclip other day. If is there any space in the path, no image will be saved on `img`. Fixed adding a function that escapes special characters on vimscript.