### PR TITLE
fix os detection / adjust mimetype filter

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,7 +1,7 @@
 function! SafeMakeDir()
     if has('win32')
         let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
-    else    
+    else
         let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
     endif
     if !isdirectory(outdir)
@@ -61,15 +61,15 @@ endfunction
 
 function! SaveFileTMP(imgdir, tmpname)
     " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
-    let os = "Windows"
+    let l:os = "Windows"
     if !(has("win64") || has("win32") || has("win16"))
-        let os = substitute(system('uname'), '\n', '', '')
+        let l:os = substitute(system('uname'), '\n', '', '')
     endif
-    if os == "Darwin"
+    if l:os == "Darwin"
         return SaveFileTMPMacOS(a:imgdir, a:tmpname)
-    elseif os == "Linux"
+    elseif l:os == "Linux"
         return SaveFileTMPLinux(a:imgdir, a:tmpname)
-    elseif os == "Windows"
+    elseif l:os == "Windows"
         return SaveFileTMPWin32(a:imgdir, a:tmpname)
     endif
 endfunction

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,5 +1,5 @@
 function! SafeMakeDir()
-    if has('win32')
+    if s:os == "Windows"
         let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
     else
         let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
@@ -60,16 +60,11 @@ function! SaveFileTMPMacOS(imgdir, tmpname) abort
 endfunction
 
 function! SaveFileTMP(imgdir, tmpname)
-    " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
-    let l:os = "Windows"
-    if !(has("win64") || has("win32") || has("win16"))
-        let l:os = substitute(system('uname'), '\n', '', '')
-    endif
-    if l:os == "Darwin"
+    if s:os == "Darwin"
         return SaveFileTMPMacOS(a:imgdir, a:tmpname)
-    elseif l:os == "Linux"
+    elseif s:os == "Linux"
         return SaveFileTMPLinux(a:imgdir, a:tmpname)
-    elseif l:os == "Windows"
+    elseif s:os == "Windows"
         return SaveFileTMPWin32(a:imgdir, a:tmpname)
     endif
 endfunction
@@ -102,6 +97,12 @@ function! RandomName()
 endfunction
 
 function! mdip#MarkdownClipboardImage()
+    " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
+    let s:os = "Windows"
+    if !(has("win64") || has("win32") || has("win16"))
+        let s:os = substitute(system('uname'), '\n', '', '')
+    endif
+
     let workdir = SafeMakeDir()
     " change temp-file-name and image-name
     let g:mdip_tmpname = RandomName()

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -13,7 +13,7 @@ endfunction
 function! SaveFileTMPLinux(imgdir, tmpname) abort
     let targets = filter(
                 \ systemlist('xclip -selection clipboard -t TARGETS -o'),
-                \ 'v:val =~# ''image''')
+                \ 'v:val =~# ''image/''')
     if empty(targets) | return 1 | endif
 
     let mimetype = targets[0]

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -60,16 +60,17 @@ function! SaveFileTMPMacOS(imgdir, tmpname) abort
 endfunction
 
 function! SaveFileTMP(imgdir, tmpname)
-    if has('unix')
-      "from mac https://superuser.com/a/193638/15231
-        let s:uname = system("uname")
-            if s:uname == "Darwin\n"
-                return SaveFileTMPMacOS(a:imgdir, a:tmpname)
-        endif
-    elseif has('win32')
-        return SaveFileTMPWin32(a:imgdir, a:tmpname)
-    else
+    " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
+    let os = "Windows"
+    if !(has("win64") || has("win32") || has("win16"))
+        let os = substitute(system('uname'), '\n', '', '')
+    endif
+    if os == "Darwin"
+        return SaveFileTMPMacOS(a:imgdir, a:tmpname)
+    elseif os == "Linux"
         return SaveFileTMPLinux(a:imgdir, a:tmpname)
+    elseif os == "Windows"
+        return SaveFileTMPWin32(a:imgdir, a:tmpname)
     endif
 endfunction
 


### PR DESCRIPTION
Linux has `unix` as well, the script would never enter the last else.
I found this solution on [stackexchange](https://vi.stackexchange.com/a/2577), it works for me, but I have not enough VimScript experience to tell if this is a good solution.

I could only test this with my ArchLinux Installation, where the
script uses the correct tmp file function now.

---

I also noticed, that the "wrong" mimetype was used.
My xclip returns `application/x-qt-image` as the first result, which is also matched by searching for `image` only.