### PR TITLE
WIP Use custom image name instead of date

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -96,6 +96,13 @@ function! RandomName()
     return l:new_random
 endfunction
 
+function! InputName()
+    call inputsave()
+    let name = input('Image name: ')
+    call inputrestore()
+    return name
+endfunction
+
 function! mdip#MarkdownClipboardImage()
     " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
     let s:os = "Windows"
@@ -105,7 +112,7 @@ function! mdip#MarkdownClipboardImage()
 
     let workdir = SafeMakeDir()
     " change temp-file-name and image-name
-    let g:mdip_tmpname = RandomName()
+    let g:mdip_tmpname = InputName()
     " let g:mdip_imgname = g:mdip_tmpname
 
     let tmpfile = SaveFileTMP(workdir, g:mdip_tmpname)


### PR DESCRIPTION
As we spoke in https://github.com/ferrine/md-img-paste.vim/issues/15 , this allows customizing the image name instead of using the current datetime.

I would like to hear what is the best way to integrate this option to the plugin. I see some options here:

1) Always ask for input, but use the date if input is empty
2) Have two commands/functions, one for pasting using date as name and another for asking input
3) Keep a single command and use a config value to control behaviour

What do you think?