### PR TITLE
Easier image naming

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -131,7 +131,11 @@ function! mdip#MarkdownClipboardImage()
         " let relpath = SaveNewFile(g:mdip_imgdir, tmpfile)
         let extension = split(tmpfile, '\.')[-1]
         let relpath = g:mdip_imgdir . '/' . g:mdip_tmpname . '.' . extension
-        execute "normal! i![Image](" . relpath . ")"
+        execute "normal! i![I"
+		let ipos = getcurpos()
+		execute "normal! amage](" . relpath . ")"
+		call setpos('.', ipos)
+		execute "normal! ve\<C-g>"
     endif
 endfunction
 


### PR DESCRIPTION
After pasting, it moves the cursor to `Image` placeholder in `select-mode`
which allows and promotes providing an alt name for the embedded image.    
Preview:
![preview](https://media.giphy.com/media/mEDW4xtg9k34FXQHbo/giphy.gif)