### PR TITLE
Add WSL support

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,3 +1,14 @@
+" https://stackoverflow.com/questions/57014805/check-if-using-windows-console-in-vim-while-in-windows-subsystem-for-linux
+function! s:IsWSL()
+    if has("unix")
+        let lines = readfile("/proc/version")
+        if lines[0] =~ "Microsoft"
+            return 1
+        endif
+    endif
+    return 0
+endfunction
+
 function! s:SafeMakeDir()
     if s:os == "Windows"
         let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
@@ -8,6 +19,24 @@ function! s:SafeMakeDir()
         call mkdir(outdir)
     endif
     return fnameescape(outdir)
+endfunction
+
+function! s:SaveFileTMPWSL(imgdir, tmpname) abort
+    let tmpfile = a:imgdir . '/' . a:tmpname . '.png'
+    let tmpfile = substitute(system("wslpath -m ".tmpfile), '\n\+$', '', '')
+
+    let clip_command = "Add-Type -AssemblyName System.Windows.Forms;"
+    let clip_command .= "if ([Windows.Forms.Clipboard]::ContainsImage()) {"
+    let clip_command .= "[Windows.Forms.Clipboard]::GetImage().Save(\\\""
+    let clip_command .= tmpfile ."\\\", [System.Drawing.Imaging.ImageFormat]::Png) }"
+    let clip_command = "powershell.exe -sta \"".clip_command. "\""
+
+    call system(clip_command)
+    if v:shell_error == 1
+        return 1
+    else
+        return tmpfile
+    endif
 endfunction
 
 function! s:SaveFileTMPLinux(imgdir, tmpname) abort
@@ -66,7 +95,9 @@ function! s:SaveFileTMPMacOS(imgdir, tmpname) abort
 endfunction
 
 function! s:SaveFileTMP(imgdir, tmpname)
-    if s:os == "Darwin"
+    if s:IsWSL()
+        return s:SaveFileTMPWSL(a:imgdir, a:tmpname)
+    elseif s:os == "Darwin"
         return s:SaveFileTMPMacOS(a:imgdir, a:tmpname)
     elseif s:os == "Linux"
         return s:SaveFileTMPLinux(a:imgdir, a:tmpname)


### PR DESCRIPTION
I wanted to paste the contents of the Windows clipboard when using WSL's VIM.

The WSL environment was determined to be Linux by the previous program.
So I change to determine the WSL environment and to save the clipboard contents
as an image with powershell.

In a WSL environment, `C:\` will be written as `/mnt/c/`.
The difference between this WSL and Windows path is converted by the `wslpath`
command.

A newline is removed by `substitute()` because an extra newline is added at the
end.

This change would force the WSL environment to use the Windows clipboard
instead of the Linux clipboard.
WSL is used with Windows, so I don't think this change is a problem, but it
might be better to have the option to switch the behavior if necessary.