### PR TITLE
Fix #19: handles path with space

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -7,7 +7,11 @@ function! s:SafeMakeDir()
     if !isdirectory(outdir)
         call mkdir(outdir)
     endif
-    return fnameescape(outdir)
+    if s:os == "Darwin"
+        return outdir
+    else
+        return fnameescape(outdir)
+    endif
 endfunction
 
 function! s:SaveFileTMPLinux(imgdir, tmpname) abort


### PR DESCRIPTION
Do not espace `outdir` in `s:SafeMakeDir` on mac, it will be handled in `oascript`.