### PR TITLE
Allow different paths to save and reference image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Yet simple tool to paste images into markdown files
 ## Use Case
 You are editing a markdown file and have an image on the clipboard and want to paste it into the document as the text `![](img/image1.png)`. Instead of first copying it to that directory, you want to do it with a single `<leader>p` key press in Vim. So it hooks `<leader>p`, checks if you are editing a Markdown file, saves the image from the clipboard to the location  `img/image1.png`, and inserts `![](img/image1.png)` into the file.
 
+By default, the location of the saved file (`img/image1.png`) and the in-text reference (`![](img/image1.png`) are identical. You can change this behavior by specyfing an absolute path to save the file (`let g:mdip_imgdir_absolute = /absolute/path/to/imgdir` on linux) and a different path for in-text references (`let g:mdip_imdir_intext = /relative/path/to/imgdir` on linux). 
+
 ## Installation
 
 Using Vundle

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -10,10 +10,14 @@ function! s:IsWSL()
 endfunction
 
 function! s:SafeMakeDir()
-    if s:os == "Windows"
-        let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
+    if !exists('g:mdip_imgdir_absolute')
+        if s:os == "Windows"  
+            let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
     else
-        let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
+            let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
+        endif
+    else 
+	let outdir = g:mdip_imgdir
     endif
     if !isdirectory(outdir)
         call mkdir(outdir)
@@ -171,7 +175,7 @@ function! mdip#MarkdownClipboardImage()
     else
         " let relpath = s:SaveNewFile(g:mdip_imgdir, tmpfile)
         let extension = split(tmpfile, '\.')[-1]
-        let relpath = g:mdip_imgdir . '/' . g:mdip_tmpname . '.' . extension
+        let relpath = g:mdip_imgdir_intext . '/' . g:mdip_tmpname . '.' . extension
         execute "normal! i![I"
         let ipos = getcurpos()
         execute "normal! amage](" . relpath . ")"
@@ -180,8 +184,16 @@ function! mdip#MarkdownClipboardImage()
     endif
 endfunction
 
-if !exists('g:mdip_imgdir')
+if !exists('g:mdip_imgdir') && !exists('g:mdip_imgdir_absolute')
     let g:mdip_imgdir = 'img'
+endif
+"allow absolute paths. E.g., on linux: /home/path/to/imgdir/
+if exists('g:mdip_imgdir_absolute')
+    let g:mdip_imgdir = g:mdip_imgdir_absolute
+endif
+"allow a different intext reference for relative links
+if !exists('g:mdip_imgdir_intext')
+    let g:mdip_imgdir_intext = g:mdip_imgdir
 endif
 if !exists('g:mdip_tmpname')
     let g:mdip_tmpname = 'tmp'


### PR DESCRIPTION
Allow absolute paths to save image with `let g:mdip_imgdir_absolute` and
allow relative in-text references `let g:mdip_imgdir_intext`.

Tested on linux.