### PR TITLE
Fix errors on macOS for WSL detection

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,22 +1,13 @@
 " https://stackoverflow.com/questions/57014805/check-if-using-windows-console-in-vim-while-in-windows-subsystem-for-linux
-function! s:IsWSL()
-    if has("unix")
-        let lines = readfile("/proc/version")
-        if lines[0] =~ "Microsoft"
-            return 1
-        endif
-    endif
-    return 0
-endfunction
 
 function! s:SafeMakeDir()
     if !exists('g:mdip_imgdir_absolute')
-        if s:os == "Windows"  
+        if s:os == "Windows"
             let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
     else
             let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
         endif
-    else 
+    else
 	let outdir = g:mdip_imgdir
     endif
     if !isdirectory(outdir)
@@ -103,9 +94,7 @@ function! s:SaveFileTMPMacOS(imgdir, tmpname) abort
 endfunction
 
 function! s:SaveFileTMP(imgdir, tmpname)
-    if s:IsWSL()
-        return s:SaveFileTMPWSL(a:imgdir, a:tmpname)
-    elseif s:os == "Darwin"
+    if s:os == "Darwin"
         return s:SaveFileTMPMacOS(a:imgdir, a:tmpname)
     elseif s:os == "Linux"
         return s:SaveFileTMPLinux(a:imgdir, a:tmpname)

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,5 +1,5 @@
 " https://stackoverflow.com/questions/57014805/check-if-using-windows-console-in-vim-while-in-windows-subsystem-for-linux
-function! IsWSL()
+function! s:IsWSL()
     let lines = readfile("/proc/version")
     if lines[0] =~ "Microsoft"
         return 1

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -101,14 +101,14 @@ function! s:SaveFileTMPMacOS(imgdir, tmpname) abort
 endfunction
 
 function! s:SaveFileTMP(imgdir, tmpname)
-    if s:os == "Darwin"
-        return s:SaveFileTMPMacOS(a:imgdir, a:tmpname)
-    elseif s:os == "Linux"
+    if s:os == "Linux"
         " Linux could also mean Windowns Subsystem for Linux
         if s:IsWSL()
             return s:SaveFileTMPWSL(a:imgdir, a:tmpname)
         endif
         return s:SaveFileTMPLinux(a:imgdir, a:tmpname)
+    elseif s:os == "Darwin"
+        return s:SaveFileTMPMacOS(a:imgdir, a:tmpname)
     elseif s:os == "Windows"
         return s:SaveFileTMPWin32(a:imgdir, a:tmpname)
     endif

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,4 +1,11 @@
 " https://stackoverflow.com/questions/57014805/check-if-using-windows-console-in-vim-while-in-windows-subsystem-for-linux
+function! IsWSL()
+    let lines = readfile("/proc/version")
+    if lines[0] =~ "Microsoft"
+        return 1
+    endif
+    return 0
+endfunction
 
 function! s:SafeMakeDir()
     if !exists('g:mdip_imgdir_absolute')
@@ -97,6 +104,10 @@ function! s:SaveFileTMP(imgdir, tmpname)
     if s:os == "Darwin"
         return s:SaveFileTMPMacOS(a:imgdir, a:tmpname)
     elseif s:os == "Linux"
+        " Linux could also mean Windowns Subsystem for Linux
+        if s:IsWSL()
+            return s:SaveFileTMPWSL(a:imgdir, a:tmpname)
+        endif
         return s:SaveFileTMPLinux(a:imgdir, a:tmpname)
     elseif s:os == "Windows"
         return s:SaveFileTMPWin32(a:imgdir, a:tmpname)


### PR DESCRIPTION
Relating to issues #33 and #35 

The problem is solely that when detecting the OS, the file `/proc/version` is read. Darwin does not contain this file so it throws an error. It's better to [nest the check for WSL in the `s:os == "Linux"` line](https://github.com/jackno/md-img-paste.vim/blob/fdb634347dc425c08bedb400fe4f0b971bbe1e30/plugin/mdip.vim#L106).

The issue may still persist (#34) that an error will be thrown on WSL that don't contain the `proc/version` file. I don't have WSL to test.

This PR fixes the issue on macOS.