### PR TITLE
Fix error on MacOS

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -1,6 +1,6 @@
 " https://stackoverflow.com/questions/57014805/check-if-using-windows-console-in-vim-while-in-windows-subsystem-for-linux
 function! s:IsWSL()
-    if has("unix")
+    if has("unix")&& s:os != "Darwin"
         let lines = readfile("/proc/version")
         if lines[0] =~ "Microsoft"
             return 1


### PR DESCRIPTION
There is no proc FS on MacOS but exists('unix') is true, so this prevents crash on MacOS