### PR TITLE
Filename prefixed image directory name

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ autocmd FileType markdown nmap <buffer><silent> <leader>p :call mdip#MarkdownCli
 " there are some defaults for image directory and image name, you can change them
 " let g:mdip_imgdir = 'img'
 " let g:mdip_imgname = 'image'
+" let g:mdip_imgdir_filename_prefix = 0 
 ```
 
 ### For linux user

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -199,6 +199,10 @@ endif
 if exists('g:mdip_imgdir_absolute')
     let g:mdip_imgdir = g:mdip_imgdir_absolute
 endif
+"prefix dir name with filename_ (without extension)
+if exists('g:mdip_imgdir_filename_prefix') && g:mdip_imgdir_filename_prefix == 1
+	let g:mdip_imgdir = expand("%:r") . "_" . g:mdip_imgdir
+endif
 "allow a different intext reference for relative links
 if !exists('g:mdip_imgdir_intext')
     let g:mdip_imgdir_intext = g:mdip_imgdir


### PR DESCRIPTION
This commit tries to work on #49 
An option to put all the images of current markdown file in a
directory with current filename without the extension prefixed to
`mdip_imgdir`with an underscore in between.
This is supposed to help organize images related to multiple
markdown documents in the same directory.

For more customization, use `expand()` inside `mdip_imgdir`
Eg:
```vim
" The following will save all the images in the directory
../all_images/currentfilename_without_extension
let g:mdip_imgdir = '../all_images' . expand('%:r')
```