### PR TITLE
Extend to other markup languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,32 @@ autocmd FileType markdown nmap <buffer><silent> <leader>p :call mdip#MarkdownCli
 " let g:mdip_imgname = 'image'
 ```
 
+### Extend to other markup languages ###
+Simply add a custom paste function that accepts the relative path to the image as an argument, and set `g:PasteImageFunction` to the name of your function. E.g. 
+```
+function! g:LatexPasteImage(relpath)
+    execute "normal! i\\includegraphics{" . a:relpath . "}\r\\caption{I"
+    let ipos = getcurpos()
+    execute "normal! a" . "mage}"
+    call setpos('.', ipos)
+    execute "normal! ve\<C-g>"
+endfunction
+```
+Then in your .vimrc:
+```
+autocmd FileType markdown let g:PasteImageFunction = 'g:MarkdownPasteImage'
+autocmd FileType tex let g:PasteImageFunction = 'g:LatexPasteImage'
+```
+The former sets the (default) markdown paste function for markdown files, while the latter sets the new latex paste function to be used in latex/tex files. The above LatesPasteImage has already been added to the plugin, see `plugin/mdip.vim`. Existing paste functions:
+
+| Filetype | Function name | Content |
+|----------|---------------|---------|
+| Markdown | MarkdownPasteImate | `![Image](path)` |
+| Latex | LatexPasteImate | `\includegraphics{path} \caption{Image}` |
+| N/A  | EmptyPasteImate | `path` |
+
+PRs welcome
+
 ### For linux user
 This plugin gets clipboard content by running the `xclip` command.
 

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -185,6 +185,18 @@ function! g:MarkdownPasteImage(relpath)
         execute "normal! vt]\<C-g>"
 endfunction
 
+function! g:LatexPasteImage(relpath)
+    execute "normal! i\\includegraphics{" . a:relpath . "}\r\\caption{I"
+    let ipos = getcurpos()
+    execute "normal! a" . "mage}"
+    call setpos('.', ipos)
+    execute "normal! ve\<C-g>"
+endfunction
+
+function! g:EmptyPasteImage(relpath)
+    execute "normal! i" . a:relpath 
+endfunction
+
 let g:PasteImageFunction = 'g:MarkdownPasteImage'
 
 function! mdip#MarkdownClipboardImage()

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -177,6 +177,16 @@ function! s:InputName()
     return name
 endfunction
 
+function! g:MarkdownPasteImage(relpath)
+        execute "normal! i![" . g:mdip_tmpname[0:0]
+        let ipos = getcurpos()
+        execute "normal! a" . g:mdip_tmpname[1:] . "](" . a:relpath . ")"
+        call setpos('.', ipos)
+        execute "normal! vt]\<C-g>"
+endfunction
+
+let g:PasteImageFunction = 'g:MarkdownPasteImage'
+
 function! mdip#MarkdownClipboardImage()
     " detect os: https://vi.stackexchange.com/questions/2572/detect-os-in-vimscript
     let s:os = "Windows"
@@ -198,11 +208,9 @@ function! mdip#MarkdownClipboardImage()
         " let relpath = s:SaveNewFile(g:mdip_imgdir, tmpfile)
         let extension = split(tmpfile, '\.')[-1]
         let relpath = g:mdip_imgdir_intext . '/' . g:mdip_tmpname . '.' . extension
-        execute "normal! i![" . g:mdip_tmpname[0:0]
-        let ipos = getcurpos()
-        execute "normal! a" . g:mdip_tmpname[1:] . "](" . relpath . ")"
-        call setpos('.', ipos)
-        execute "normal! vt]\<C-g>"
+        if call(get(g:, 'PasteImageFunction'), [relpath])
+            return
+        endif
     endif
 endfunction
 


### PR DESCRIPTION
I finally got around to create a suggestion based on #42 

This makes the plugin call the possibly-user-defined function g:PasteImageFunction instead of doing Markdown-specific inserts.
The old behaviour has been separated into the MarkdownPasteImage function, which I have set g:PasteImageFunction to default to.

I've also included two example paste functions: one for latex and another that just pastes the path of the image (in case you just want to save the image and have its path). These are defined within the plugin (which I think makes sense for common languages), put can also be defined by the user in vimrc.

I tagged this as WIP since it is my first vimscript PR, and I have some questions and comments:

- is the way I set the default value for PasteImageFunction ok?
- the if in front of the call to the PasteImageFunction was seemingly needed because call() is a function
- ~~I was unsuccessful in my attepts at setting PasteImageFunction based on the filetype (autocmd), but I'm hoping that someone can give some pointers :) For now I have just set the PastImageFunction manually. Here is what I tried~~ This now magically works. Probably had a problem with my vim settings
```
autocmd FileType markdown,tex nmap <buffer><silent> <leader>p :call mdip#MarkdownClipboardImage()<CR>
autocmd FileType markdown let g:PasteImageFunction = 'g:MarkdownPasteImage'
autocmd FileType tex let g:PasteImageFunction = 'g:LatexPasteImage'
```  

Looking forward to hearing what you think!