### PR TITLE
Implement imgdir_filename_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Yet simple tool to paste images into markdown files
 ## Use Case
 You are editing a markdown file and have an image on the clipboard and want to paste it into the document as the text `![](img/image1.png)`. Instead of first copying it to that directory, you want to do it with a single `<leader>p` key press in Vim. So it hooks `<leader>p`, checks if you are editing a Markdown file, saves the image from the clipboard to the location  `img/image1.png`, and inserts `![](img/image1.png)` into the file.
 
-By default, the location of the saved file (`img/image1.png`) and the in-text reference (`![](img/image1.png`) are identical. You can change this behavior by specyfing an absolute path to save the file (`let g:mdip_imgdir_absolute = /absolute/path/to/imgdir` on linux) and a different path for in-text references (`let g:mdip_imgdir_intext = /relative/path/to/imgdir` on linux). 
+By default, the location of the saved file (`img/image1.png`) and the in-text reference (`![](img/image1.png`) are identical. You can change this behavior by specyfing an absolute path to save the file (`let g:mdip_imgdir_absolute = /absolute/path/to/imgdir` on linux) and a different path for in-text references (`let g:mdip_imgdir_intext = /relative/path/to/imgdir` on linux).
 
 ## Installation
 
@@ -22,8 +22,18 @@ autocmd FileType markdown nmap <buffer><silent> <leader>p :call mdip#MarkdownCli
 " let g:mdip_imgname = 'image'
 ```
 
+## Prefix imgdir with file name
+
+To prefix `imgdir` with the name of the file, add the following to your .vimrc :
+```
+let g:mdip_imgdir_filename_prefix=1
+```
+In this case, the images you copy into a file called `test.md` would be located in `test_img`
+
+/!\ You can't use both `mdip_imgdir_absolute` and `mdip_imgdir_filename_prefix` at the same time.
+
 ### Extend to other markup languages ###
-Simply add a custom paste function that accepts the relative path to the image as an argument, and set `g:PasteImageFunction` to the name of your function. E.g. 
+Simply add a custom paste function that accepts the relative path to the image as an argument, and set `g:PasteImageFunction` to the name of your function. E.g.
 ```
 function! g:LatexPasteImage(relpath)
     execute "normal! i\\includegraphics{" . a:relpath . "}\r\\caption{I"

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -209,7 +209,7 @@ function! mdip#MarkdownClipboardImage()
 
     " prefix dir name with filename_ (without extension)
     if exists('g:mdip_imgdir_filename_prefix') && g:mdip_imgdir_filename_prefix == 1
-        let g:mdip_final_imgdir = expand("%:r") . "_" . g:mdip_imgdir
+        let g:mdip_final_imgdir = g:mdip_imgdir . '/' . expand("%:r")
     else
         let g:mdip_final_imgdir = g:mdip_imgdir
     endif
@@ -223,7 +223,7 @@ function! mdip#MarkdownClipboardImage()
     " change temp-file-name and image-name
     let g:mdip_tmpname = s:InputName()
     if empty(g:mdip_tmpname)
-        let g:mdip_tmpname = g:mdip_imgname . '_' . s:RandomName()
+        let g:mdip_tmpname = g:mdip_imgname . '/' . s:RandomName()
     endif
 
     let tmpfile = s:SaveFileTMP(workdir, g:mdip_tmpname)


### PR DESCRIPTION
Use final_imgdir and final_imgdir_intext to support multiple files
Rework SafeMakeDir to not call any global variables

Fix #50 not working when editing multiple files