### PR TITLE
WIP: Add setting to save image based on buffer name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # img-paste.vim
+
 Yet simple tool to paste images into markdown files
+
+* [Use Case](#use-case)
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Extend to other markup languages](#extend-to-other-markup-languages)
+  * [Asciidoctor](#asciidoctor)
+  * [For linux user](#for-linux-user)
+* [Acknowledgements](#acknowledgements)
 
 ## Use Case
 You are editing a markdown file and have an image on the clipboard and want to paste it into the document as the text `![](img/image1.png)`. Instead of first copying it to that directory, you want to do it with a single `<leader>p` key press in Vim. So it hooks `<leader>p`, checks if you are editing a Markdown file, saves the image from the clipboard to the location  `img/image1.png`, and inserts `![](img/image1.png)` into the file.
@@ -10,7 +19,7 @@ By default, the location of the saved file (`img/image1.png`) and the in-text re
 
 Using Vundle
 ```
-Plugin 'img-paste-devs/img-paste.vim'
+Plugin 'ferrine/md-img-paste.vim'
 ```
 
 ## Usage
@@ -46,15 +55,49 @@ autocmd FileType markdown,tex nmap <buffer><silent> <leader>p :call mdip#Markdow
                         '----'
 ```
 
+### Asciidoctor
+
+For [Asciidoctor](https://asciidoctor.org/), something like this should get you started:
+
+```viml
+""
+" Paste image inside an `.adoc` (Asciidoc[tor]) document.
+"
+"   image::./img/<name.png>[Image description]
+"
+function! g:AsciidocPasteImage(relpath)
+    execute "normal! iimage::./" . a:relpath . "[I"
+    let ipos = getcurpos()
+    execute "normal! a" . "mage description]"
+    call setpos('.', ipos)
+    execute "normal! vi[\<C-g>"
+endfunction
+
+""
+" Set `AsciidocPastImage` as the paste function for Asciidoc
+" (or Asciidoctor) buffers.
+"
+autocmd FileType asciidoctor
+      \ let g:PasteImageFunction = 'g:AsciidocPasteImage'
+
+""
+" Type <Leader>p to paste the image.
+"
+autocmd FileType asciidoctor
+      \ nmap <buffer><silent> <leader>p
+      \ :call mdip#MarkdownClipboardImage()<CR>
+```
+
 | Filetype | Function name | Content |
 |----------|---------------|---------|
 | Markdown | MarkdownPasteImage | `![Image](path)` |
 | Latex | LatexPasteImage | `\includegraphics{path} \caption{Image}` |
+| Asciidoc | AsciidocPasteImage | `image::./path[Image]` |
 | N/A  | EmptyPasteImage | `path` |
 
 PRs welcome
 
-### For linux user
+### For Linux user
 This plugin gets clipboard content by running the `xclip` command.
 
 install `xclip` first.

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -8,17 +8,27 @@ function! s:IsWSL()
 endfunction
 
 function! s:SafeMakeDir()
-    if !exists('g:mdip_imgdir_absolute')
+    ""
+    " Assets directory based on the basename of the current buffer.
+    "
+    if exists('g:mdip_imgdir_bufname')
+        ""
+        " The full path to the current buffer without the extension.
+        "
+        let path = expand('%:p:r')
+        let outdir = path . '.assets'
+    elseif !exists('g:mdip_imgdir_absolute')
         if s:os == "Windows"
             let outdir = expand('%:p:h') . '\' . g:mdip_imgdir
-    else
+        else
             let outdir = expand('%:p:h') . '/' . g:mdip_imgdir
         endif
     else
-	let outdir = g:mdip_imgdir
+        let outdir = g:mdip_imgdir
     endif
+
     if !isdirectory(outdir)
-        call mkdir(outdir,"p",0700)
+        call mkdir(outdir, "p", 0700)
     endif
     if s:os == "Darwin"
         return outdir
@@ -137,11 +147,11 @@ function! s:SaveFileTMP(imgdir, tmpname)
 endfunction
 
 function! s:SaveNewFile(imgdir, tmpfile)
-    let extension = split(a:tmpfile, '\.')[-1]
+    let ext = split(a:tmpfile, '\.')[-1]
     let reldir = g:mdip_imgdir
     let cnt = 0
-    let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
-    let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+    let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . ext
+    let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . ext
     while filereadable(filename)
         call system('diff ' . a:tmpfile . ' ' . filename)
         if !v:shell_error
@@ -149,8 +159,8 @@ function! s:SaveNewFile(imgdir, tmpfile)
             return relpath
         endif
         let cnt += 1
-        let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
-        let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+        let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . ext
+        let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . ext
     endwhile
     if filereadable(a:tmpfile)
         call rename(a:tmpfile, filename)
@@ -194,7 +204,7 @@ function! g:LatexPasteImage(relpath)
 endfunction
 
 function! g:EmptyPasteImage(relpath)
-    execute "normal! i" . a:relpath 
+    execute "normal! i" . a:relpath
 endfunction
 
 let g:PasteImageFunction = 'g:MarkdownPasteImage'
@@ -244,7 +254,15 @@ if exists('g:mdip_imgdir_absolute')
 endif
 "allow a different intext reference for relative links
 if !exists('g:mdip_imgdir_intext')
-    let g:mdip_imgdir_intext = g:mdip_imgdir
+    ""
+    " Assets directory based on the name of the current buffer.
+    "
+    if exists('g:mdip_imgdir_bufname')
+        let path = expand('%:r')
+        let g:mdip_imgdir_intext = path . '.assets'
+    else
+        let g:mdip_imgdir_intext = g:mdip_imgdir
+    endif
 endif
 if !exists('g:mdip_tmpname')
     let g:mdip_tmpname = 'tmp'


### PR DESCRIPTION
NOTE: This is a work in progress.

Sometimes, we want to move a document around and then we have to search for its related images and move them around too, individually, or update image paths inside documents.

This PR allows for one extra setting which will make it possible to insert images in a directory named after the current buffer name.

For example, if the current buffer is `docs/intro.adoc`, the image will be copied to `docs/intro.assets/<img-name>.png`.

Or, if the current buffer is `notes/fp/concepts.md`, then the image will be `notes/fp/concepts.assets/<img-name>.png`.

It should work the same no matter the document file extension.

This allows for the document file and its assets directory to be moved together so that wherever the document is moved too, the images (or other assets, potentially) are moved together.

PS: I copied this idea from Typora (not sure if Typora invented it, but it is where I saw it and found it a useful approach for certain scenarios).