### PR TITLE
Pin default shell to cmd.exe on windows

### DIFF
--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -149,8 +149,13 @@ function! s:SaveNewFile(imgdir, tmpfile)
     let extension = split(a:tmpfile, '\.')[-1]
     let reldir = g:mdip_imgdir
     let cnt = 0
-    let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
-    let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+    if empty(g:mdip_imgname)
+      let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
+      let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+    else
+      let filename = a:imgdir . '/' . cnt . '.' . extension
+      let relpath = reldir . '/' . cnt . '.' . extension
+    endif
     while filereadable(filename)
         call system('diff ' . a:tmpfile . ' ' . filename)
         if !v:shell_error
@@ -158,8 +163,13 @@ function! s:SaveNewFile(imgdir, tmpfile)
             return relpath
         endif
         let cnt += 1
-        let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
-        let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+        if empty(g:mdip_imgname)
+          let filename = a:imgdir . '/' . g:mdip_imgname . cnt . '.' . extension
+          let relpath = reldir . '/' . g:mdip_imgname . cnt . '.' . extension
+        else
+          let filename = a:imgdir . '/' . cnt . '.' . extension
+          let relpath = reldir . '/' . cnt . '.' . extension
+        endif
     endwhile
     if filereadable(a:tmpfile)
         call rename(a:tmpfile, filename)
@@ -202,8 +212,16 @@ function! g:LatexPasteImage(relpath)
     execute "normal! ve\<C-g>"
 endfunction
 
+function! g:TypstPasteImage(relpath)
+        let ipos = getcurpos()
+        execute "normal! iimage(\"" . a:relpath . "\")"
+        call setpos('.', ipos)
+endfunction
+
 function! g:EmptyPasteImage(relpath)
+    let ipos = getcurpos()
     execute "normal! i" . a:relpath
+    call setpos('.', ipos)
 endfunction
 
 let g:PasteImageFunction = 'g:MarkdownPasteImage'
@@ -221,7 +239,11 @@ function! mdip#MarkdownClipboardImage()
         " change temp-file-name and image-name
         let g:mdip_tmpname = s:InputName()
         if empty(g:mdip_tmpname)
-          let g:mdip_tmpname = g:mdip_imgname . '_' . s:RandomName()
+          if empty(g:mdip_imgname)
+            let g:mdip_tmpname = s:RandomName()
+          else
+            let g:mdip_tmpname = g:mdip_imgname . '_' . s:RandomName()
+          endif
         endif
         let testpath =  workdir . '/' . g:mdip_tmpname . '.png'
         if filereadable(testpath) == 0

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -237,8 +237,7 @@ function! mdip#MarkdownClipboardImage()
     else
         " let relpath = s:SaveNewFile(g:mdip_imgdir, tmpfile)
         let extension = split(tmpfile, '\.')[-1]
-        let sep = has('win32') ? '\' : '/'
-        let relpath = g:mdip_imgdir_intext . sep . g:mdip_tmpname . '.' . extension
+        let relpath = g:mdip_imgdir_intext . '/' . g:mdip_tmpname . '.' . extension
         if call(get(g:, 'PasteImageFunction'), [relpath])
             return
         endif

--- a/plugin/mdip.vim
+++ b/plugin/mdip.vim
@@ -89,6 +89,11 @@ function! s:SaveFileTMPLinux(imgdir, tmpname) abort
 endfunction
 
 function! s:SaveFileTMPWin32(imgdir, tmpname) abort
+    let shell_bak = &shell
+    let shellcmdflag_bak = &shellcmdflag
+    let &shell = 'cmd.exe'
+    let &shellcmdflag = '/s /c'
+
     let tmpfile = a:imgdir . '\' . a:tmpname . '.png'
     let tmpfile = substitute(tmpfile, '\\ ', ' ', 'g')
 
@@ -99,6 +104,10 @@ function! s:SaveFileTMPWin32(imgdir, tmpname) abort
     let clip_command = "powershell -nologo -noprofile -noninteractive -sta \"".clip_command. "\""
 
     silent call system(clip_command)
+
+    let &shell = shell_bak
+    let &shellcmdflag = shellcmdflag_bak
+
     if v:shell_error == 1
         return 1
     else
@@ -194,7 +203,7 @@ function! g:LatexPasteImage(relpath)
 endfunction
 
 function! g:EmptyPasteImage(relpath)
-    execute "normal! i" . a:relpath 
+    execute "normal! i" . a:relpath
 endfunction
 
 let g:PasteImageFunction = 'g:MarkdownPasteImage'
@@ -228,7 +237,8 @@ function! mdip#MarkdownClipboardImage()
     else
         " let relpath = s:SaveNewFile(g:mdip_imgdir, tmpfile)
         let extension = split(tmpfile, '\.')[-1]
-        let relpath = g:mdip_imgdir_intext . '/' . g:mdip_tmpname . '.' . extension
+        let sep = has('win32') ? '\' : '/'
+        let relpath = g:mdip_imgdir_intext . sep . g:mdip_tmpname . '.' . extension
         if call(get(g:, 'PasteImageFunction'), [relpath])
             return
         endif


### PR DESCRIPTION
I have set my default shell to powershell 7 (`let &shell='pwsh'`), but the command in function `s:SaveFileTMPWin32` is `cmd.exe` format.
So I realized we should backup the original shell first (defined by `&shell` and `&shellcmdflag`, run `:h system` for more information), then run the "powershell paste image" command, finally we should recover the original shell. If we don't change the `&shell` to `cmd.exe`, it will `return 1` indicates the command failed.